### PR TITLE
Update example log format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,17 @@ JSON format. This gem contains that logger.
 ```json
 {
   "@timestamp": "2014-06-05T12:38:42Z",
-  "pid": 8630,
-  "tid": "TID-osammcf2k",
-  "context": "TrainingIndexer::Work JID-177066e96052c2314dcad8c7",
-  "severity": "INFO",
-  "program_name": "TrainingIndexer::Work",
-  "type": "sidekiq",
-  "message": "2014-06-05T12:38:42Z 8630 TID-osammcf2k TrainingIndexer::Work JID-177066e96052c2314dcad8c7 INFO: done: 51.579 sec",
-  "status": "done",
-  "run_time": 51.579
+  "@fields": {
+    "pid": 8630,
+    "tid": "TID-osammcf2k",
+    "context": "TrainingIndexer::Work JID-177066e96052c2314dcad8c7",
+    "program_name": "TrainingIndexer::Work"
+  },
+  "@type": "sidekiq",
+  "@status": "done",
+  "@severity": "INFO",
+  "@run_time": 51.579,
+  "@message": "2014-06-05T12:38:42Z 8630 TID-osammcf2k TrainingIndexer::Work JID-177066e96052c2314dcad8c7 INFO: done: 51.579 sec"
 }
 ```
 


### PR DESCRIPTION
Since 2d15a0b the log example in the README has not matched the updated format actually used by the gem.
